### PR TITLE
Remove QT from base image

### DIFF
--- a/2.1/Dockerfile
+++ b/2.1/Dockerfile
@@ -1,8 +1,8 @@
 FROM ruby:2.1
 
 RUN apt-get update -qq \
-  && apt-get -y install build-essential libpq-dev libqt4-dev git wget \
-  libyaml-dev postgresql-client-9.4 xvfb nodejs npm \
+  && apt-get -y install build-essential libpq-dev git wget \
+  libyaml-dev postgresql-client-9.4 nodejs npm \
   && rm -rf /var/lib/apt/lists/*
 
 COPY imagemagick-policy.xml /etc/ImageMagick-6/policy.xml

--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -1,8 +1,8 @@
 FROM ruby:2.2
 
 RUN apt-get update -qq \
-  && apt-get -y install build-essential libpq-dev libqt4-dev git wget \
-  libyaml-dev postgresql-client-9.4 xvfb nodejs npm \
+  && apt-get -y install build-essential libpq-dev git wget \
+  libyaml-dev postgresql-client-9.4 nodejs npm \
   && rm -rf /var/lib/apt/lists/*
 
 COPY imagemagick-policy.xml /etc/ImageMagick-6/policy.xml

--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -1,8 +1,8 @@
 FROM ruby:2.3
 
 RUN apt-get update -qq \
-  && apt-get -y install build-essential libpq-dev libqt4-dev git wget \
-  libyaml-dev postgresql-client-9.4 xvfb nodejs npm \
+  && apt-get -y install build-essential libpq-dev git wget \
+  libyaml-dev postgresql-client-9.4 nodejs npm \
   && rm -rf /var/lib/apt/lists/*
 
 COPY imagemagick-policy.xml /etc/ImageMagick-6/policy.xml


### PR DESCRIPTION
This increases the size of the base image by a ton.

We should simply install this in projects that need it. The vast majority of our projects do not need it.