### PR TITLE
install nodejs version 0.12 to ruby image

### DIFF
--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -1,8 +1,10 @@
 FROM ruby:2.3
 
+RUN curl -sL https://deb.nodesource.com/setup_0.12 | bash -
+
 RUN apt-get update -qq \
   && apt-get -y install build-essential libpq-dev libqt4-dev git wget \
-  libyaml-dev postgresql-client-9.4 xvfb nodejs npm \
+  libyaml-dev postgresql-client-9.4 xvfb nodejs \
   && rm -rf /var/lib/apt/lists/*
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh


### PR DESCRIPTION
installing nodejs version `0.12` to our articulate-ruby docker image - was using version `0.10` before