### PR TITLE
WIP :: Structural change, bump node & add yarn

### DIFF
--- a/2.4/node/7/Dockerfile
+++ b/2.4/node/7/Dockerfile
@@ -1,0 +1,38 @@
+FROM ruby:2.4
+
+ENV SERVICE_ROOT /service
+ENV SERVICE_USER service
+ENV YARN_VERSION 0.22.0
+
+RUN curl -sL https://deb.nodesource.com/setup_7.x | bash -
+
+RUN apt-get update -qq \
+  && apt-get -y install build-essential libpq-dev libqt4-dev git wget \
+  libyaml-dev postgresql-client-9.4 xvfb nodejs \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN set -ex \
+  && for key in \
+    6A010C5166006599AA17F08146C2130DFD2497F5 \
+  ; do \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
+    gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \
+  done \
+  && curl -fSL -o yarn.js "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-legacy-$YARN_VERSION.js" \
+  && curl -fSL -o yarn.js.asc "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-legacy-$YARN_VERSION.js.asc" \
+  && gpg --batch --verify yarn.js.asc yarn.js \
+  && rm yarn.js.asc \
+  && mv yarn.js /usr/local/bin/yarn \
+  && chmod +x /usr/local/bin/yarn
+
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
+RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
+
+RUN groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER
+WORKDIR $SERVICE_ROOT
+
+ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /wait-for-it.sh
+RUN chmod a+rx /wait-for-it.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,6 @@ build_2_3:
 
 build_2_4:
 	docker build -t articulate/articulate-ruby:2.4 2.4/
+
+build_2_4_node_7:
+	docker build -t articulate/articulate-ruby:2.4 2.4/node/7/


### PR DESCRIPTION
cc @pklingem 

There's a request for WWW (and I assume Heroes at some point) to be switched from NPM shrinkwrap to yarn, but in order to do that we need to get a newer version of Node. If there are better ideas for how to accomplish this, I'm all ears!

Questions:
  * What other projects would this affect and need to be updated?
  * Is the Makefile change acceptable, or should the commands themselves be updated to reflect both ruby version _and_ node version? I'm comfortable with leaving it as-is for getting the latest Node
  * Latest yarn version is 0.23.x -- should I be using that, instead, or is there a reason we're using 0.22.0 in the `docker-articulate-node` project?