### PR TITLE
Update npm to 6.4.1 to fix security vulnerabilities

### DIFF
--- a/2.4-alpine/Dockerfile
+++ b/2.4-alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:2.4-alpine3.7
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
-ENV NPM_VER=6.1.0
+ENV NPM_VER=6.4.1
 
 RUN apk add --no-cache make libpq qt git curl wget yaml postgresql-client xvfb bash nodejs binutils jq sudo unzip
 

--- a/2.4-alpine/Dockerfile
+++ b/2.4-alpine/Dockerfile
@@ -21,5 +21,7 @@ RUN npm uninstall npm -g
 RUN wget https://registry.npmjs.org/npm/-/npm-${NPM_VER}.tgz \
   && tar xzf npm-${NPM_VER}.tgz \
   && ./package/scripts/install.sh
+RUN rm npm-${NPM_VER}.tgz
+RUN rm -rf /service/package/
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
This PR bumps the NPM version from 6.1.0 to the (currently) most recent one, 6.4.1.

This helps us get rid of a vulnerability in cryptiles (CVE-2018-1000620), as well as a few medium/low vulnerabilities too.

