### PR TITLE
Add Dockerfile for 2.4-debian-stretch-slim

### DIFF
--- a/2.4-stretch-slim/Dockerfile
+++ b/2.4-stretch-slim/Dockerfile
@@ -1,0 +1,47 @@
+# Debian-based image maintained by Ruby, see https://hub.docker.com/_/ruby for a full list of available images.
+# Source for this base image can be found at https://github.com/docker-library/ruby/tree/master/2.4/stretch/slim
+FROM ruby:2.4-slim-stretch
+
+# Let's update and install the things.
+# Run apt-get quietly (-qq) and say yes to prompts (-y)
+# See best practices for apt-get in Docker at https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run
+# Notes:
+#   - postgresql-client requires the presence of man pages for some reason. Debian-slim doesn't have those by default, so we have to add those as a stub (source: https://github.com/dalibo/temboard/issues/211)
+#   - we install Imagemagick in our base image so we can keep it updated in one place, and so we can add a strict security policy by default (see further down)
+RUN apt-get update -qq \
+    && apt-get upgrade -y \
+    && mkdir -p /usr/share/man/man1 \
+    && mkdir -p /usr/share/man/man7 \
+    && apt-get install -y build-essential imagemagick git wget curl xvfb binutils jq sudo unzip qt5-default libpq-dev postgresql-client-9.6
+
+# Add a strict security policy for Imagemagick (note: Imagemagick 7 is currently not available in Debian)
+COPY imagemagick-policy.xml /etc/ImageMagick-6/policy.xml
+
+# Install consul-template, which we'll use to pull in our environment variables
+# If you want to know more on this, see the Platform 101 course, section "Consul and Vault"
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
+RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
+
+# We use the following variables both in here and in downstream Dockerfiles
+ENV SERVICE_ROOT /service
+ENV SERVICE_USER service
+
+# Create our service group and user, and set the directory where we'll work from going forward
+RUN groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER
+WORKDIR $SERVICE_ROOT
+
+# Make the wait-for-it script available to all projects.
+# This is sometimes used by projects to make sure that supporting containers are up before the app starts.
+# As an example, see the Makefile in the Heroes project.
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
+RUN chmod a+rx /wait-for-it.sh
+
+# We want npm in our base image. To get it, we must install nodejs. There is one in apt-get, but it's super old (version ~4). To get a newer node we must first add the nodesource PPA.
+# Source: https://github.com/nodesource/distributions/blob/master/README.md#deb
+# At the time of writing the installation of Node 8 (LTS) gives us npm 6.4.1. Node 8 will be EOL in December 2019.
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN apt-get update -qq && apt-get install -y nodejs
+
+# Our entrypoint will pull in our environment variables from Consul and Vault, and execute whatever command we provided the container.
+# See https://github.com/articulate/docker-consul-template-bootstrap/blob/master/entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/2.4-stretch-slim/imagemagick-policy.xml
+++ b/2.4-stretch-slim/imagemagick-policy.xml
@@ -1,0 +1,22 @@
+<!--
+  The policy.xml file is used by Imagemagick to define a security policy.
+
+  In our case we want to only allow the processing of safe image formats, and prevent any
+  use of Imagemagick's other functions like PDF or movie handling, since those are often implicated in security vulnerabilities.
+
+  Information on previously reported Imagemagick vulnerabilities and policy.xml based mitigations can be found here:
+  - https://www.openwall.com/lists/oss-security/2018/08/21/2
+  - https://imagetragick.com/
+  - https://www.kb.cert.org/vuls/id/332928/
+  - https://www.imagemagick.org/discourse-server/viewtopic.php?t=34617
+
+  This file should be placed in /etc/Imagemagick-6 (at least on our current Debian distribution).
+  We do this by way of a COPY command in the Dockerfile.
+  Once the file is in place, you can check if ImageMagick picks it up by issuing the command "convert -list policy" from a regular shell.
+-->
+<policymap>
+  <policy domain="delegate" rights="none" pattern="*" />
+  <policy domain="filter" rights="none" pattern="*" />
+  <policy domain="coder" rights="none" pattern="*" />
+  <policy domain="coder" rights="read|write" pattern="{GIF,JPEG,PNG,WEBP}" />
+</policymap>


### PR DESCRIPTION
We're switching base images from Alpine to debian-slim for security reasons.
This PR adds a Dockerfile for debian-stretch-slim. 