### PR TITLE
make is required for certain tests to run in pipeline

### DIFF
--- a/2.5-stretch-slim-minimal/Dockerfile
+++ b/2.5-stretch-slim-minimal/Dockerfile
@@ -8,7 +8,7 @@ FROM ruby:2.5-slim-stretch
 # Notes:
 #
 RUN apt-get update -qq \
-    && apt-get install -y git wget curl xvfb binutils jq sudo unzip \
+    && apt-get install -y make git wget curl xvfb binutils jq sudo unzip \
     && apt-get upgrade -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /usr/share/doc /root/.cache/


### PR DESCRIPTION
Identified in pipeline run (on auth-engine) that package `make` is required for certain tests to actually kick off.