### PR TITLE
Remove qt and xvfb from non-qt image

### DIFF
--- a/2.5-stretch-slim/Dockerfile
+++ b/2.5-stretch-slim/Dockerfile
@@ -11,8 +11,8 @@ FROM ruby:2.5-slim-stretch
 RUN apt-get update -qq \
     && mkdir -p /usr/share/man/man1 \
     && mkdir -p /usr/share/man/man7 \
-    && apt-get install -y build-essential imagemagick git wget curl xvfb \
-    binutils jq sudo unzip qt5-default libyaml-dev libpq-dev \
+    && apt-get install -y build-essential imagemagick git wget curl \
+    binutils jq sudo unzip libyaml-dev libpq-dev \
     postgresql-client-9.6 \
     && apt-get upgrade -y \
     && apt-get clean \

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ These are all built on Dockerhub as Automated Builds: https://hub.docker.com/r/a
 
 ### 2.7-buster-slim-minimal
 
-This is our recommended build if you don't need `node`, `qt5`, `imagemagick` or `postgres-client`
+This is our recommended build if you don't need `node`, `imagemagick` or `postgres-client`
 
 ### 2.7-buster-slim
 
@@ -19,7 +19,7 @@ This is our recommended build if you need any of the requirements not provided i
 
 ### 2.6-stretch-slim-minimal
 
-This is our recommended 2.6 build if you don't need `node`, `qt5`, `imagemagick` or `postgres-client`
+This is our recommended 2.6 build if you don't need `node`, `imagemagick` or `postgres-client`
 
 ### 2.6-stretch-slim
 
@@ -34,11 +34,10 @@ This is our recommended 2.5 build if you don't need `node`, `qt5`, `imagemagick`
 
 ### 2.5-stretch-slim
 
-This is our recommended 2.5 build if you don't need `qt5`
+This is our recommended 2.5 build if you don't need `qt5` or `xvfb`
 
 - Node: Latest 12.x
 - Postgres Client: Latest 9.6.x
-- QT: Latest available in stretch
 
 ### 2.5-stretch-slim-qt
 


### PR DESCRIPTION
Services that need qt now are based on the `-qt` suffix'd image.