### PR TITLE
Add new Ruby 2.6 image with Debian Bullseye

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,9 @@ jobs:
           - 2.6-stretch-slim
           - 2.6-stretch-slim-minimal
           - 2.6-stretch-slim-qt
+          - 2.6-bullseye-slim
+          - 2.6-bullseye-slim-minimal
+          - 2.6-bullseye-slim-qt
           - 2.7-buster-slim
           - 2.7-buster-slim-minimal
           - 2.7-buster-slim-qt

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,9 @@ jobs:
           - 2.6-stretch-slim
           - 2.6-stretch-slim-minimal
           - 2.6-stretch-slim-qt
+          - 2.6-bullseye-slim
+          - 2.6-bullseye-slim-minimal
+          - 2.6-bullseye-slim-qt
           - 2.7-buster-slim
           - 2.7-buster-slim-minimal
           - 2.7-buster-slim-qt

--- a/2.6-bullseye-slim-minimal/Dockerfile
+++ b/2.6-bullseye-slim-minimal/Dockerfile
@@ -1,0 +1,28 @@
+FROM ruby:2.6-slim-bullseye
+
+ENV SERVICE_ROOT /service
+ENV SERVICE_USER service
+
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
+
+RUN apt-get update -qq \
+    && apt-get install --no-install-recommends -y \
+        make git wget curl xvfb binutils jq sudo unzip \
+    && apt-get upgrade -y \
+    && apt-get clean \
+    # Consul template
+    && bash /tmp/consul_template_install.sh \
+    # Make wait-for-it executable
+    && chmod a+rx /wait-for-it.sh \
+    # Create our service group and user
+    && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
+    # Cleanup
+    && rm -rf /var/lib/apt/lists/* /usr/share/doc /root/.cache/ /tmp/*
+
+WORKDIR $SERVICE_ROOT
+
+# Our entrypoint will pull in our environment variables from Consul and Vault
+# and execute whatever command we provided the container.
+# See https://github.com/articulate/docker-consul-template-bootstrap/blob/master/entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/2.6-bullseye-slim-qt/Dockerfile
+++ b/2.6-bullseye-slim-qt/Dockerfile
@@ -1,0 +1,40 @@
+FROM ruby:2.6-slim-bullseye
+
+ENV SERVICE_ROOT /service
+ENV SERVICE_USER service
+
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
+ADD https://deb.nodesource.com/setup_16.x /tmp/setup-node.sh
+
+# - postgresql-client requires the presence of man pages for some reason. Debian-slim doesn't have those by default, so we have to add those as a stub (source: https://github.com/dalibo/temboard/issues/211)
+# - we install Imagemagick in our base image so we can keep it updated in one place, and so we can add a strict security policy by default (see further down)
+# - We want npm in our base image. To get it, we must install nodejs. There is one in apt-get, but it's super old (version ~4). To get a newer node we must first add the nodesource PPA.
+#   Source: https://github.com/nodesource/distributions/blob/master/README.md#deb
+RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
+    && bash /tmp/setup-node.sh \
+    && apt-get update -qq \
+    && apt-get install --no-install-recommends -y \
+        build-essential imagemagick git wget curl xvfb binutils jq sudo unzip \
+        qt5-default libqt5webkit5-dev libyaml-dev libpq-dev postgresql-client-9.6 \
+        nodejs \
+    && apt-get upgrade -y \
+    && apt-get clean \
+    # Consul template
+    && bash /tmp/consul_template_install.sh \
+    # Create our service group and user
+    && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
+    # Make wait-for-it executable
+    && chmod a+rx /wait-for-it.sh \
+    # cleanup
+    && rm -rf /var/lib/apt/lists/* /usr/share/doc /root/.cache/ /tmp/*
+
+# Add a strict security policy for Imagemagick (note: Imagemagick 7 is currently not available in Debian)
+COPY imagemagick-policy.xml /etc/ImageMagick-6/policy.xml
+
+WORKDIR $SERVICE_ROOT
+
+# Our entrypoint will pull in our environment variables from Consul and Vault
+# and execute whatever command we provided the container.
+# See https://github.com/articulate/docker-consul-template-bootstrap/blob/master/entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/2.6-bullseye-slim-qt/imagemagick-policy.xml
+++ b/2.6-bullseye-slim-qt/imagemagick-policy.xml
@@ -1,0 +1,32 @@
+<!--
+  The policy.xml file is used by Imagemagick to define a security policy.
+
+  In our case we want to only allow the processing of safe image formats, and prevent any
+  use of Imagemagick's other functions like PDF or movie handling, since those are often implicated in security vulnerabilities.
+
+  Information on previously reported Imagemagick vulnerabilities and policy.xml based mitigations can be found here:
+  - https://www.openwall.com/lists/oss-security/2018/08/21/2
+  - https://imagetragick.com/
+  - https://www.kb.cert.org/vuls/id/332928/
+  - https://www.imagemagick.org/discourse-server/viewtopic.php?t=34617
+
+  This file should be placed in /etc/Imagemagick-6 (at least on our current Debian distribution).
+  We do this by way of a COPY command in the Dockerfile.
+
+  To verify the policy:
+  - use the command 'identify -list policy' to see if the policy file gets picked up
+  - use 'identify' on various image types to see if Imagemagick allows/blocks what you want it to
+  (Tip: use wget to pull in various files in your local container to test them out)
+
+  Note: most Imagemagick documentation shows a security policy with an aggregate pattern, like {GIF,JPEG,PNG,WEBP}
+  However, that only works from Imagemagick 6.9.7-9 upwards, and Debian 9 gives us only 6.9.7-4 at this time.
+  So here we have to specify them on seperate lines.
+-->
+<policymap>
+  <policy domain="delegate" rights="none" pattern="*" />
+  <policy domain="filter" rights="none" pattern="*" />
+  <policy domain="coder" rights="read|write" pattern="GIF" />
+  <policy domain="coder" rights="read|write" pattern="PNG" />
+  <policy domain="coder" rights="read|write" pattern="WEBP" />
+  <policy domain="coder" rights="read|write" pattern="JPEG" />
+</policymap>

--- a/2.6-bullseye-slim/Dockerfile
+++ b/2.6-bullseye-slim/Dockerfile
@@ -1,0 +1,39 @@
+FROM ruby:2.6-slim-bullseye
+
+ENV SERVICE_ROOT /service
+ENV SERVICE_USER service
+
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
+ADD https://deb.nodesource.com/setup_16.x /tmp/setup-node.sh
+
+# - postgresql-client requires the presence of man pages for some reason. Debian-slim doesn't have those by default, so we have to add those as a stub (source: https://github.com/dalibo/temboard/issues/211)
+# - we install Imagemagick in our base image so we can keep it updated in one place, and so we can add a strict security policy by default (see further down)
+# - We want npm in our base image. To get it, we must install nodejs. There is one in apt-get, but it's super old (version ~4). To get a newer node we must first add the nodesource PPA.
+#   Source: https://github.com/nodesource/distributions/blob/master/README.md#deb
+RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
+    && bash /tmp/setup-node.sh \
+    && apt-get update -qq \
+    && apt-get install --no-install-recommends -y \
+        build-essential imagemagick git wget curl binutils jq sudo unzip \
+        libyaml-dev libpq-dev postgresql-client-9.6 nodejs \
+    && apt-get upgrade -y \
+    && apt-get clean \
+    # Consul template
+    && bash /tmp/consul_template_install.sh \
+    # Create our service group and user
+    && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
+    # Make wait-for-it executable
+    && chmod a+rx /wait-for-it.sh \
+    # cleanup
+    && rm -rf /var/lib/apt/lists/* /usr/share/doc /root/.cache/ /tmp/*
+
+# Add a strict security policy for Imagemagick (note: Imagemagick 7 is currently not available in Debian)
+COPY imagemagick-policy.xml /etc/ImageMagick-6/policy.xml
+
+WORKDIR $SERVICE_ROOT
+
+# Our entrypoint will pull in our environment variables from Consul and Vault
+# and execute whatever command we provided the container.
+# See https://github.com/articulate/docker-consul-template-bootstrap/blob/master/entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/2.6-bullseye-slim/imagemagick-policy.xml
+++ b/2.6-bullseye-slim/imagemagick-policy.xml
@@ -1,0 +1,32 @@
+<!--
+  The policy.xml file is used by Imagemagick to define a security policy.
+
+  In our case we want to only allow the processing of safe image formats, and prevent any
+  use of Imagemagick's other functions like PDF or movie handling, since those are often implicated in security vulnerabilities.
+
+  Information on previously reported Imagemagick vulnerabilities and policy.xml based mitigations can be found here:
+  - https://www.openwall.com/lists/oss-security/2018/08/21/2
+  - https://imagetragick.com/
+  - https://www.kb.cert.org/vuls/id/332928/
+  - https://www.imagemagick.org/discourse-server/viewtopic.php?t=34617
+
+  This file should be placed in /etc/Imagemagick-6 (at least on our current Debian distribution).
+  We do this by way of a COPY command in the Dockerfile.
+
+  To verify the policy:
+  - use the command 'identify -list policy' to see if the policy file gets picked up
+  - use 'identify' on various image types to see if Imagemagick allows/blocks what you want it to
+  (Tip: use wget to pull in various files in your local container to test them out)
+
+  Note: most Imagemagick documentation shows a security policy with an aggregate pattern, like {GIF,JPEG,PNG,WEBP}
+  However, that only works from Imagemagick 6.9.7-9 upwards, and Debian 9 gives us only 6.9.7-4 at this time.
+  So here we have to specify them on seperate lines.
+-->
+<policymap>
+  <policy domain="delegate" rights="none" pattern="*" />
+  <policy domain="filter" rights="none" pattern="*" />
+  <policy domain="coder" rights="read|write" pattern="GIF" />
+  <policy domain="coder" rights="read|write" pattern="PNG" />
+  <policy domain="coder" rights="read|write" pattern="WEBP" />
+  <policy domain="coder" rights="read|write" pattern="JPEG" />
+</policymap>

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all: 2.5 2.6 2.7
 
 2.5: 2.5-stretch-slim 2.5-stretch-slim-minimal 2.5-stretch-slim-qt
 
-2.6: 2.6-stretch-slim 2.6-stretch-slim-minimal 2.6-stretch-slim-qt
+2.6: 2.6-stretch-slim 2.6-stretch-slim-minimal 2.6-stretch-slim-qt 2.6-bullseye-slim 2.6-bullseye-slim-minimal 2.6-bullseye-slim-qt
 
 2.7: 2.7-buster-slim 2.7-buster-slim-minimal 2.7-buster-slim-qt
 
@@ -31,6 +31,18 @@ all: 2.5 2.6 2.7
 2.6-stretch-slim-qt:
 	docker build -t local/articulate-ruby:2.6-stretch-slim-qt 2.6-stretch-slim-qt
 .PHONY: 2.6-stretch-slim-qt
+
+2.6-bullseye-slim:
+	docker build -t local/articulate-ruby:2.6-bullseye-slim 2.6-bullseye-slim
+.PHONY: 2.6-bullseye-slim
+
+2.6-bullseye-slim-minimal:
+	docker build -t local/articulate-ruby:2.6-bullseye-slim-minimal 2.6-bullseye-slim-minimal
+.PHONY: 2.6-bullseye-slim-minimal
+
+2.6-bullseye-slim-qt:
+	docker build -t local/articulate-ruby:2.6-bullseye-slim-qt 2.6-bullseye-slim-qt
+.PHONY: 2.6-bullseye-slim-qt
 
 2.7-buster-slim:
 	docker build -t local/articulate-ruby:2.7-buster-slim 2.7-buster-slim

--- a/README.md
+++ b/README.md
@@ -22,16 +22,16 @@ This is our recommended build if you need any of the requirements not provided i
 
 ## Ruby 2.6
 
-### 2.6-stretch-slim-minimal
+### 2.6-bullseye-slim-minimal
 
 This is our recommended 2.6 build if you don't need `node`, `imagemagick` or `postgres-client`
 
-### 2.6-stretch-slim
+### 2.6-bullseye-slim
 
-- Node: Latest 12.x
+- Node: Latest 16.x
 - Postgres Client: Latest 9.6.x
 
-### 2.6-stretch-slim-qt
+### 2.6-bullseye-slim-qt
 
 This is our recommended build if you need any of the requirements not provided in `*-minimal` and also need `qt`
 
@@ -53,17 +53,3 @@ This is our recommended 2.5 build if you don't need `qt5` or `xvfb`
 - Node: Latest 12.x
 - Postgres Client: Latest 9.6.x
 - QT: Latest available in stretch
-
-## Ruby 2.4
-
-*Ruby 2.4 is end of life, DO NOT USE*
-
-### 2.4-alpine
-
-- Node: uses the latest node available for alpine 3.7
-- Postgres Client: uses the latest postgres-client available for alpine 3.7
-
-### 2.4-stretch-slim
-
-- Node: Latest 8.x
-- Postgres Client: Latest 9.6.x


### PR DESCRIPTION
This commit adds a new Ruby 2.6 image running Debian Bullseye.

On the MarkOps team we use a library called Nokogiri which now supports
Apple Silicon with the caveat that you have to have a version of `glibc >= 2.9`. 
This version only exists in Debian Bullseye so we're upgrading
in order to better support Apple Silicon on the MarkOps team.

I opted to create additional images instead of modifying the existing
one so that other teams are not affected by this change.



## New Image Checklist

If you're adding a new image, make sure you have done the following.

* [x] Added to lint workflow matrix (`.github/workflows/lint.yml`)
* [x] Added to build workflow matrix (`.github/workflows/build.yml`)
* [x] Added to Makefile (`Makefile`)
