### PR TITLE
Change how postgresql-client-9.6 and qt5 are installed in Bullseye

### DIFF
--- a/2.6-bullseye-slim-qt/Dockerfile
+++ b/2.6-bullseye-slim-qt/Dockerfile
@@ -11,13 +11,18 @@ ADD https://deb.nodesource.com/setup_16.x /tmp/setup-node.sh
 # - we install Imagemagick in our base image so we can keep it updated in one place, and so we can add a strict security policy by default (see further down)
 # - We want npm in our base image. To get it, we must install nodejs. There is one in apt-get, but it's super old (version ~4). To get a newer node we must first add the nodesource PPA.
 #   Source: https://github.com/nodesource/distributions/blob/master/README.md#deb
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     && bash /tmp/setup-node.sh \
     && apt-get update -qq \
     && apt-get install --no-install-recommends -y \
         build-essential imagemagick git wget curl xvfb binutils jq sudo unzip \
-        qt5-default libqt5webkit5-dev libyaml-dev libpq-dev postgresql-client-9.6 \
-        nodejs \
+        qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools libqt5webkit5-dev \
+        libyaml-dev libpq-dev nodejs \
+    && echo "deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
+    && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
+    && apt-get update -qq \
+    && apt-get install --no-install-recommends -y postgresql-client-9.6 \
     && apt-get upgrade -y \
     && apt-get clean \
     # Consul template

--- a/2.6-bullseye-slim/Dockerfile
+++ b/2.6-bullseye-slim/Dockerfile
@@ -11,12 +11,17 @@ ADD https://deb.nodesource.com/setup_16.x /tmp/setup-node.sh
 # - we install Imagemagick in our base image so we can keep it updated in one place, and so we can add a strict security policy by default (see further down)
 # - We want npm in our base image. To get it, we must install nodejs. There is one in apt-get, but it's super old (version ~4). To get a newer node we must first add the nodesource PPA.
 #   Source: https://github.com/nodesource/distributions/blob/master/README.md#deb
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     && bash /tmp/setup-node.sh \
     && apt-get update -qq \
     && apt-get install --no-install-recommends -y \
         build-essential imagemagick git wget curl binutils jq sudo unzip \
-        libyaml-dev libpq-dev postgresql-client-9.6 nodejs \
+        libyaml-dev libpq-dev nodejs \
+    && echo "deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
+    && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
+    && apt-get update -qq \
+    && apt-get install --no-install-recommends -y postgresql-client-9.6 \
     && apt-get upgrade -y \
     && apt-get clean \
     # Consul template


### PR DESCRIPTION
This commit changes how qt5-default and postgresql-client-9.6 are
installed on our Ruby Bullseye image.

When running this image on Apple Silicon we ran into two issues: We needed
the postgres-sql-client from the official Postgres repository and we
needed to install the qt5-default packages individually. This image now
builds successfully on Apple Silicon (tested locally by devs with Apple
Silicon).

Unfortunately because neither `curl` or `wget` is initially installed, I
had to run the update command twice once for the Debian packages and
once for the Postgres packages. This also means we're running an
install twice respectively. We'll remove this code once we get postgres
updated to a version in the Debian repo (>= 13).



## New Image Checklist

If you're adding a new image, make sure you have done the following.

* [ ] Added to lint workflow matrix (`.github/workflows/lint.yml`)
* [ ] Added to build workflow matrix (`.github/workflows/build.yml`)
* [ ] Added to Makefile (`Makefile`)
