### PR TITLE
Update 2.6 Bullseye image to use latest postgres-client

### DIFF
--- a/2.6-bullseye-slim-qt/Dockerfile
+++ b/2.6-bullseye-slim-qt/Dockerfile
@@ -11,18 +11,13 @@ ADD https://deb.nodesource.com/setup_16.x /tmp/setup-node.sh
 # - we install Imagemagick in our base image so we can keep it updated in one place, and so we can add a strict security policy by default (see further down)
 # - We want npm in our base image. To get it, we must install nodejs. There is one in apt-get, but it's super old (version ~4). To get a newer node we must first add the nodesource PPA.
 #   Source: https://github.com/nodesource/distributions/blob/master/README.md#deb
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     && bash /tmp/setup-node.sh \
     && apt-get update -qq \
     && apt-get install --no-install-recommends -y \
         build-essential imagemagick git wget curl xvfb binutils jq sudo unzip \
         qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools libqt5webkit5-dev \
-        libyaml-dev libpq-dev nodejs \
-    && echo "deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
-    && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
-    && apt-get update -qq \
-    && apt-get install --no-install-recommends -y postgresql-client-9.6 \
+        libyaml-dev libpq-dev nodejs postgresql-client \
     && apt-get upgrade -y \
     && apt-get clean \
     # Consul template

--- a/2.6-bullseye-slim/Dockerfile
+++ b/2.6-bullseye-slim/Dockerfile
@@ -11,17 +11,12 @@ ADD https://deb.nodesource.com/setup_16.x /tmp/setup-node.sh
 # - we install Imagemagick in our base image so we can keep it updated in one place, and so we can add a strict security policy by default (see further down)
 # - We want npm in our base image. To get it, we must install nodejs. There is one in apt-get, but it's super old (version ~4). To get a newer node we must first add the nodesource PPA.
 #   Source: https://github.com/nodesource/distributions/blob/master/README.md#deb
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     && bash /tmp/setup-node.sh \
     && apt-get update -qq \
     && apt-get install --no-install-recommends -y \
         build-essential imagemagick git wget curl binutils jq sudo unzip \
-        libyaml-dev libpq-dev nodejs \
-    && echo "deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
-    && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
-    && apt-get update -qq \
-    && apt-get install --no-install-recommends -y postgresql-client-9.6 \
+        libyaml-dev libpq-dev nodejs postgresql-client \
     && apt-get upgrade -y \
     && apt-get clean \
     # Consul template

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This is our recommended 2.6 build if you don't need `node`, `imagemagick` or `po
 ### 2.6-bullseye-slim
 
 - Node: Latest 16.x
-- Postgres Client: Latest 9.6.x
+- Postgres Client: Latest postgres-client in `bullseye`
 
 ### 2.6-bullseye-slim-qt
 


### PR DESCRIPTION
This commit updates the Ruby 2.6 Bullseye image to use the latest
Postgres client as the MarkOps team is preparing to upgrade our
databases to Postgres 13 in AWS.

We're going to let this sit on stage and use it locally while we wait
for our one week notice to customers to pass so we can upgrade during
our scheduled maintenace window.



## New Image Checklist

If you're adding a new image, make sure you have done the following.

* [ ] Added to lint workflow matrix (`.github/workflows/lint.yml`)
* [ ] Added to build workflow matrix (`.github/workflows/build.yml`)
* [ ] Added to Makefile (`Makefile`)
