### PR TITLE
add 2.7-bullseye-slim image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
           - 2.7-buster-slim
           - 2.7-buster-slim-minimal
           - 2.7-buster-slim-qt
+          - 2.7-bullseye-slim
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,7 @@ jobs:
           - 2.7-buster-slim
           - 2.7-buster-slim-minimal
           - 2.7-buster-slim-qt
+          - 2.7-bullseye-slim
     steps:
       - uses: actions/checkout@v2
       - uses: hadolint/hadolint-action@v1.6.0

--- a/2.7-bullseye-slim/Dockerfile
+++ b/2.7-bullseye-slim/Dockerfile
@@ -1,0 +1,37 @@
+FROM ruby:2.7-slim-bullseye
+
+ENV SERVICE_ROOT /service
+ENV SERVICE_USER service
+
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
+ADD https://deb.nodesource.com/setup_16.x /tmp/setup-node.sh
+
+# - we install Imagemagick in our base image so we can keep it updated in one place, and so we can add a strict security policy by default (see further down)
+# - We want npm in our base image. To get it, we must install nodejs. There is one in apt-get, but it's super old (version ~4). To get a newer node we must first add the nodesource PPA.
+#   Source: https://github.com/nodesource/distributions/blob/master/README.md#deb
+RUN bash /tmp/setup-node.sh \
+    && apt-get update -qq \
+    && apt-get install --no-install-recommends -y \
+        build-essential imagemagick git wget curl binutils jq sudo unzip \
+        libyaml-dev libpq-dev nodejs postgresql-client \
+    && apt-get upgrade -y \
+    && apt-get clean \
+    # Consul template
+    && bash /tmp/consul_template_install.sh \
+    # Create our service group and user
+    && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
+    # Make wait-for-it executable
+    && chmod a+rx /wait-for-it.sh \
+    # cleanup
+    && rm -rf /var/lib/apt/lists/* /usr/share/doc /root/.cache/ /tmp/*
+
+# Add a strict security policy for Imagemagick (note: Imagemagick 7 is currently not available in Debian)
+COPY imagemagick-policy.xml /etc/ImageMagick-6/policy.xml
+
+WORKDIR $SERVICE_ROOT
+
+# Our entrypoint will pull in our environment variables from Consul and Vault
+# and execute whatever command we provided the container.
+# See https://github.com/articulate/docker-consul-template-bootstrap/blob/master/entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/2.7-bullseye-slim/imagemagick-policy.xml
+++ b/2.7-bullseye-slim/imagemagick-policy.xml
@@ -1,0 +1,32 @@
+<!--
+  The policy.xml file is used by Imagemagick to define a security policy.
+
+  In our case we want to only allow the processing of safe image formats, and prevent any
+  use of Imagemagick's other functions like PDF or movie handling, since those are often implicated in security vulnerabilities.
+
+  Information on previously reported Imagemagick vulnerabilities and policy.xml based mitigations can be found here:
+  - https://www.openwall.com/lists/oss-security/2018/08/21/2
+  - https://imagetragick.com/
+  - https://www.kb.cert.org/vuls/id/332928/
+  - https://www.imagemagick.org/discourse-server/viewtopic.php?t=34617
+
+  This file should be placed in /etc/Imagemagick-6 (at least on our current Debian distribution).
+  We do this by way of a COPY command in the Dockerfile.
+
+  To verify the policy:
+  - use the command 'identify -list policy' to see if the policy file gets picked up
+  - use 'identify' on various image types to see if Imagemagick allows/blocks what you want it to
+  (Tip: use wget to pull in various files in your local container to test them out)
+
+  Note: most Imagemagick documentation shows a security policy with an aggregate pattern, like {GIF,JPEG,PNG,WEBP}
+  However, that only works from Imagemagick 6.9.7-9 upwards, and Debian 9 gives us only 6.9.7-4 at this time.
+  So here we have to specify them on seperate lines.
+-->
+<policymap>
+  <policy domain="delegate" rights="none" pattern="*" />
+  <policy domain="filter" rights="none" pattern="*" />
+  <policy domain="coder" rights="read|write" pattern="GIF" />
+  <policy domain="coder" rights="read|write" pattern="PNG" />
+  <policy domain="coder" rights="read|write" pattern="WEBP" />
+  <policy domain="coder" rights="read|write" pattern="JPEG" />
+</policymap>

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all: 2.5 2.6 2.7
 
 2.6: 2.6-stretch-slim 2.6-stretch-slim-minimal 2.6-stretch-slim-qt 2.6-bullseye-slim 2.6-bullseye-slim-minimal 2.6-bullseye-slim-qt
 
-2.7: 2.7-buster-slim 2.7-buster-slim-minimal 2.7-buster-slim-qt
+2.7: 2.7-buster-slim 2.7-buster-slim-minimal 2.7-buster-slim-qt 2.7-bullseye-slim
 
 .PHONY: all 2.5 2.6 2.7
 
@@ -55,3 +55,7 @@ all: 2.5 2.6 2.7
 2.7-buster-slim-qt:
 	docker build -t local/articulate-ruby:2.7-buster-slim-qt 2.7-buster-slim-qt
 .PHONY: 2.7-buster-slim-qt
+
+2.7-bullseye-slim:
+	docker build -t local/articulate-ruby:2.7-bullseye-slim 2.7-bullseye-slim
+.PHONY: 2.7-bullseye-slim

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 ## Ruby 2.7
 
+### 2.7-bullseye-slim
+
+Based off `ruby:2.7-slim-buster`.
+
+- [consul bootstrap](https://github.com/articulate/docker-consul-template-bootstrap)
+- Node 16.x
+- Postgres Client
+- ImageMagick
+
 ### 2.7-buster-slim-minimal
 
 This is our recommended build if you don't need `node`, `imagemagick` or `postgres-client`


### PR DESCRIPTION
Adds bullseye-slim for 2.7. This is needed for nokogiri 1.13 on arm64

## New Image Checklist

If you're adding a new image, make sure you have done the following.

* [x] Added to lint workflow matrix (`.github/workflows/lint.yml`)
* [x] Added to build workflow matrix (`.github/workflows/build.yml`)
* [x] Added to Makefile (`Makefile`)
