### PR TITLE
Add Ruby 3.1 Bullseye image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,9 @@ jobs:
           - 2.7-buster-slim-minimal
           - 2.7-buster-slim-qt
           - 2.7-bullseye-slim
+          - 3.1-bullseye-slim
+          - 3.1-bullseye-slim-minimal
+          - 3.1-bullseye-slim-qt
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,9 @@ jobs:
           - 2.7-buster-slim-minimal
           - 2.7-buster-slim-qt
           - 2.7-bullseye-slim
+          - 3.1-bullseye-slim
+          - 3.1-bullseye-slim-minimal
+          - 3.1-bullseye-slim-qt
     steps:
       - uses: actions/checkout@v2
       - uses: hadolint/hadolint-action@v1.6.0

--- a/3.1-bullseye-slim-minimal/Dockerfile
+++ b/3.1-bullseye-slim-minimal/Dockerfile
@@ -1,0 +1,28 @@
+FROM ruby:3.1-slim-bullseye
+
+ENV SERVICE_ROOT /service
+ENV SERVICE_USER service
+
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
+
+RUN apt-get update -qq \
+    && apt-get install --no-install-recommends -y \
+        make git wget curl binutils jq sudo unzip \
+    && apt-get upgrade -y \
+    && apt-get clean \
+    # Consul template
+    && bash /tmp/consul_template_install.sh \
+    # Make wait-for-it executable
+    && chmod a+rx /wait-for-it.sh \
+    # Create our service group and user
+    && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
+    # Cleanup
+    && rm -rf /var/lib/apt/lists/* /usr/share/doc /root/.cache/ /tmp/*
+
+WORKDIR $SERVICE_ROOT
+
+# Our entrypoint will pull in our environment variables from Consul and Vault
+# and execute whatever command we provided the container.
+# See https://github.com/articulate/docker-consul-template-bootstrap/blob/master/entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/3.1-bullseye-slim-qt/Dockerfile
+++ b/3.1-bullseye-slim-qt/Dockerfile
@@ -1,0 +1,40 @@
+FROM ruby:3.1-slim-bullseye
+
+ENV SERVICE_ROOT /service
+ENV SERVICE_USER service
+
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
+ADD https://deb.nodesource.com/setup_16.x /tmp/setup-node.sh
+
+# - postgresql-client requires the presence of man pages for some reason. Debian-slim doesn't have those by default, so we have to add those as a stub (source: https://github.com/dalibo/temboard/issues/211)
+# - we install Imagemagick in our base image so we can keep it updated in one place, and so we can add a strict security policy by default (see further down)
+# - We want npm in our base image. To get it, we must install nodejs. There is one in apt-get, but it's super old (version ~4). To get a newer node we must first add the nodesource PPA.
+#   Source: https://github.com/nodesource/distributions/blob/master/README.md#deb
+RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
+    && bash /tmp/setup-node.sh \
+    && apt-get update -qq \
+    && apt-get install --no-install-recommends -y \
+        build-essential imagemagick git wget curl xvfb binutils jq sudo unzip \
+        qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools libqt5webkit5-dev \
+        libyaml-dev libpq-dev nodejs postgresql-client \
+    && apt-get upgrade -y \
+    && apt-get clean \
+    # Consul template
+    && bash /tmp/consul_template_install.sh \
+    # Create our service group and user
+    && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
+    # Make wait-for-it executable
+    && chmod a+rx /wait-for-it.sh \
+    # cleanup
+    && rm -rf /var/lib/apt/lists/* /usr/share/doc /root/.cache/ /tmp/*
+
+# Add a strict security policy for Imagemagick
+COPY imagemagick-policy.xml /etc/ImageMagick-8/policy.xml
+
+WORKDIR $SERVICE_ROOT
+
+# Our entrypoint will pull in our environment variables from Consul and Vault
+# and execute whatever command we provided the container.
+# See https://github.com/articulate/docker-consul-template-bootstrap/blob/master/entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/3.1-bullseye-slim-qt/imagemagick-policy.xml
+++ b/3.1-bullseye-slim-qt/imagemagick-policy.xml
@@ -1,0 +1,32 @@
+<!--
+  The policy.xml file is used by Imagemagick to define a security policy.
+
+  In our case we want to only allow the processing of safe image formats, and prevent any
+  use of Imagemagick's other functions like PDF or movie handling, since those are often implicated in security vulnerabilities.
+
+  Information on previously reported Imagemagick vulnerabilities and policy.xml based mitigations can be found here:
+  - https://www.openwall.com/lists/oss-security/2018/08/21/2
+  - https://imagetragick.com/
+  - https://www.kb.cert.org/vuls/id/332928/
+  - https://www.imagemagick.org/discourse-server/viewtopic.php?t=34617
+
+  This file should be placed in /etc/Imagemagick-6 (at least on our current Debian distribution).
+  We do this by way of a COPY command in the Dockerfile.
+
+  To verify the policy:
+  - use the command 'identify -list policy' to see if the policy file gets picked up
+  - use 'identify' on various image types to see if Imagemagick allows/blocks what you want it to
+  (Tip: use wget to pull in various files in your local container to test them out)
+
+  Note: most Imagemagick documentation shows a security policy with an aggregate pattern, like {GIF,JPEG,PNG,WEBP}
+  However, that only works from Imagemagick 6.9.7-9 upwards, and Debian 9 gives us only 6.9.7-4 at this time.
+  So here we have to specify them on seperate lines.
+-->
+<policymap>
+  <policy domain="delegate" rights="none" pattern="*" />
+  <policy domain="filter" rights="none" pattern="*" />
+  <policy domain="coder" rights="read|write" pattern="GIF" />
+  <policy domain="coder" rights="read|write" pattern="PNG" />
+  <policy domain="coder" rights="read|write" pattern="WEBP" />
+  <policy domain="coder" rights="read|write" pattern="JPEG" />
+</policymap>

--- a/3.1-bullseye-slim/Dockerfile
+++ b/3.1-bullseye-slim/Dockerfile
@@ -1,0 +1,39 @@
+FROM ruby:3.1-slim-bullseye
+
+ENV SERVICE_ROOT /service
+ENV SERVICE_USER service
+
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
+ADD https://deb.nodesource.com/setup_16.x /tmp/setup-node.sh
+
+# - postgresql-client requires the presence of man pages for some reason. Debian-slim doesn't have those by default, so we have to add those as a stub (source: https://github.com/dalibo/temboard/issues/211)
+# - we install Imagemagick in our base image so we can keep it updated in one place, and so we can add a strict security policy by default (see further down)
+# - We want npm in our base image. To get it, we must install nodejs. There is one in apt-get, but it's super old (version ~4). To get a newer node we must first add the nodesource PPA.
+#   Source: https://github.com/nodesource/distributions/blob/master/README.md#deb
+RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
+    && bash /tmp/setup-node.sh \
+    && apt-get update -qq \
+    && apt-get install --no-install-recommends -y \
+        build-essential imagemagick git wget curl binutils jq sudo unzip \
+        libyaml-dev libpq-dev nodejs postgresql-client \
+    && apt-get upgrade -y \
+    && apt-get clean \
+    # Consul template
+    && bash /tmp/consul_template_install.sh \
+    # Create our service group and user
+    && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
+    # Make wait-for-it executable
+    && chmod a+rx /wait-for-it.sh \
+    # cleanup
+    && rm -rf /var/lib/apt/lists/* /usr/share/doc /root/.cache/ /tmp/*
+
+# Add a strict security policy for Imagemagick
+COPY imagemagick-policy.xml /etc/ImageMagick-8/policy.xml
+
+WORKDIR $SERVICE_ROOT
+
+# Our entrypoint will pull in our environment variables from Consul and Vault
+# and execute whatever command we provided the container.
+# See https://github.com/articulate/docker-consul-template-bootstrap/blob/master/entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/3.1-bullseye-slim/imagemagick-policy.xml
+++ b/3.1-bullseye-slim/imagemagick-policy.xml
@@ -1,0 +1,32 @@
+<!--
+  The policy.xml file is used by Imagemagick to define a security policy.
+
+  In our case we want to only allow the processing of safe image formats, and prevent any
+  use of Imagemagick's other functions like PDF or movie handling, since those are often implicated in security vulnerabilities.
+
+  Information on previously reported Imagemagick vulnerabilities and policy.xml based mitigations can be found here:
+  - https://www.openwall.com/lists/oss-security/2018/08/21/2
+  - https://imagetragick.com/
+  - https://www.kb.cert.org/vuls/id/332928/
+  - https://www.imagemagick.org/discourse-server/viewtopic.php?t=34617
+
+  This file should be placed in /etc/Imagemagick-6 (at least on our current Debian distribution).
+  We do this by way of a COPY command in the Dockerfile.
+
+  To verify the policy:
+  - use the command 'identify -list policy' to see if the policy file gets picked up
+  - use 'identify' on various image types to see if Imagemagick allows/blocks what you want it to
+  (Tip: use wget to pull in various files in your local container to test them out)
+
+  Note: most Imagemagick documentation shows a security policy with an aggregate pattern, like {GIF,JPEG,PNG,WEBP}
+  However, that only works from Imagemagick 6.9.7-9 upwards, and Debian 9 gives us only 6.9.7-4 at this time.
+  So here we have to specify them on seperate lines.
+-->
+<policymap>
+  <policy domain="delegate" rights="none" pattern="*" />
+  <policy domain="filter" rights="none" pattern="*" />
+  <policy domain="coder" rights="read|write" pattern="GIF" />
+  <policy domain="coder" rights="read|write" pattern="PNG" />
+  <policy domain="coder" rights="read|write" pattern="WEBP" />
+  <policy domain="coder" rights="read|write" pattern="JPEG" />
+</policymap>

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: 2.5 2.6 2.7
+all: 2.5 2.6 2.7 3.1
 
 2.5: 2.5-stretch-slim 2.5-stretch-slim-minimal 2.5-stretch-slim-qt
 
@@ -6,7 +6,9 @@ all: 2.5 2.6 2.7
 
 2.7: 2.7-buster-slim 2.7-buster-slim-minimal 2.7-buster-slim-qt 2.7-bullseye-slim
 
-.PHONY: all 2.5 2.6 2.7
+3.1: 3.1-bullseye-slim 3.1-bullseye-slim-minimal 3.1-bullseye-slim-qt
+
+.PHONY: all 2.5 2.6 2.7 3.1
 
 2.5-stretch-slim:
 	docker build -t local/articulate-ruby:2.5-stretch-slim 2.5-stretch-slim
@@ -59,3 +61,15 @@ all: 2.5 2.6 2.7
 2.7-bullseye-slim:
 	docker build -t local/articulate-ruby:2.7-bullseye-slim 2.7-bullseye-slim
 .PHONY: 2.7-bullseye-slim
+
+3.1-bullseye-slim:
+	docker build -t local/articulate-ruby:3.1-bullseye-slim 3.1-bullseye-slim
+.PHONY: 3.1-bullseye-slim
+
+3.1-bullseye-slim-minimal:
+	docker build -t local/articulate-ruby:3.1-bullseye-slim-minimal 3.1-bullseye-slim-minimal
+.PHONY: 3.1-bullseye-slim-minimal
+
+3.1-bullseye-slim-qt:
+	docker build -t local/articulate-ruby:3.1-bullseye-slim-qt 3.1-bullseye-slim-qt
+.PHONY: 3.1-bullseye-slim-qt

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Base Ruby images for Articulate services.
 
 | Tag                       | Ruby | Node | Postgres | ImageMagick | QT |
 |---------------------------|------|------|----------|-------------|----|
+| 3.1-bullseye-slim-minimal | 3.1  | ❌   | ❌       | ❌          | ❌ |
+| 3.1-bullseye-slim         | 3.1  | 16   | ✅       | ✅          | ❌ |
+| 3.1-bullseye-slim-qt      | 3.1  | 16   | ✅       | ✅          | ✅ |
 | 2.7-bullseye-slim         | 2.7  | 16   | ✅       | ✅          | ❌ |
 | 2.7-buster-slim-minimal   | 2.7  | ❌   | ❌       | ❌          | ❌ |
 | 2.7-buster-slim           | 2.7  | 12   | ✅       | ✅          | ❌ |


### PR DESCRIPTION
This adds a Ruby 3.1 docker image running on Debian Bullseye and it also
upgrades ImageMagick to version 8



## New Image Checklist

If you're adding a new image, make sure you have done the following.

* [x] Added to lint workflow matrix (`.github/workflows/lint.yml`)
* [x] Added to build workflow matrix (`.github/workflows/build.yml`)
* [x] Added to Makefile (`Makefile`)
* [x] Added to README (`README.md`)
