### PR TITLE
build(docker)!: docker consul bootstrap upgrade

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,18 +1,21 @@
 name: Build
 
 on:
+  pull_request:
   push:
     branches:
       - main
   schedule:
-    # Run everyday
-    - cron: "0 0 * * *"
+    # every weekday
+    - cron: '0 0 * * 1-5'
+    # every sunday (no-cache)
+    - cron: '0 0 * * 0'
   workflow_dispatch:
     inputs:
-      cache:
-        description: Use cache for build
-        required: true
-        default: 'true'
+      no-cache:
+        description: 'Skip Docker cache'
+        type: boolean
+        default: false
 
 env:
   IMAGE: articulate/articulate-ruby
@@ -45,16 +48,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
-      - id: meta
-        run: |
-          TAGS="${{ env.IMAGE }}:${{ matrix.tag }}"
-          [ -n "${{ matrix.latest }}" ] && TAGS="${TAGS},${{ env.IMAGE }}:latest"
-
-          NO_CACHE="false"
-          [ "${{ github.event.inputs.cache }}" == "false" ] && NO_CACHE="true"
-
-          echo "tags=$TAGS" >> $GITHUB_OUTPUT
-          echo "no_cache=$NO_CACHE" >> $GITHUB_OUTPUT
       - uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -62,10 +55,10 @@ jobs:
       - uses: docker/build-push-action@v3
         with:
           context: ${{ matrix.tag }}
-          pull: true
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          pull: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ env.IMAGE }}:${{ matrix.tag }}
           platforms: linux/amd64,linux/arm64/v8
           cache-from: type=registry,ref=${{ env.IMAGE }}:${{ matrix.tag }}
           cache-to: type=inline
-          no-cache: ${{ steps.meta.outputs.no_cache }}
+          no-cache: ${{ github.event.schedule == '0 0 * * 0' || (github.event_name == 'workflow_dispatch' && inputs.no-cache) }}

--- a/2.5-stretch-slim-minimal/Dockerfile
+++ b/2.5-stretch-slim-minimal/Dockerfile
@@ -1,20 +1,23 @@
+# syntax=docker/dockerfile:1
 FROM ruby:2.5-slim-stretch
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 
-ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
-ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
+ARG TARGETARCH
+ARG AWSCLI_VERSION=2.9.15
+ADD --chmod=755 https://github.com/articulate/docker-consul-template-bootstrap/releases/latest/download/docker-consul-template-bootstrap_linux_${TARGETARCH} /entrypoint
+ADD --chmod=755 https://raw.githubusercontent.com/vishnubob/wait-for-it/81b1373f17855a4dc21156cfe1694c31d7d1792e/wait-for-it.sh /wait-for-it.sh
 
 RUN apt-get update -qq \
     && apt-get install --no-install-recommends -y \
-        make git wget curl xvfb binutils jq sudo unzip \
+        make git wget curl xvfb binutils jq sudo unzip ca-certificates \
     && apt-get upgrade -y \
     && apt-get clean \
-    # Consul template
-    && bash /tmp/consul_template_install.sh \
-    # Make wait-for-it executable
-    && chmod a+rx /wait-for-it.sh \
+    # AWSCLI (to be removed in a future release)
+    && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \
+    && unzip -d /tmp /tmp/awscliv2.zip \
+    && /tmp/aws/install \
     # Create our service group and user
     && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
     # Cleanup
@@ -24,5 +27,5 @@ WORKDIR $SERVICE_ROOT
 
 # Our entrypoint will pull in our environment variables from Consul and Vault
 # and execute whatever command we provided the container.
-# See https://github.com/articulate/docker-consul-template-bootstrap/blob/master/entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+# See https://github.com/articulate/docker-consul-template-bootstrap
+ENTRYPOINT [ "/entrypoint" ]

--- a/2.5-stretch-slim-qt/Dockerfile
+++ b/2.5-stretch-slim-qt/Dockerfile
@@ -1,10 +1,13 @@
+# syntax=docker/dockerfile:1
 FROM ruby:2.5-slim-stretch
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 
-ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
-ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
+ARG TARGETARCH
+ARG AWSCLI_VERSION=2.9.15
+ADD --chmod=755 https://github.com/articulate/docker-consul-template-bootstrap/releases/latest/download/docker-consul-template-bootstrap_linux_${TARGETARCH} /entrypoint
+ADD --chmod=755 https://raw.githubusercontent.com/vishnubob/wait-for-it/81b1373f17855a4dc21156cfe1694c31d7d1792e/wait-for-it.sh /wait-for-it.sh
 ADD https://deb.nodesource.com/setup_12.x /tmp/setup-node.sh
 
 # - postgresql-client requires the presence of man pages for some reason. Debian-slim doesn't have those by default, so we have to add those as a stub (source: https://github.com/dalibo/temboard/issues/211)
@@ -19,12 +22,12 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
         qt5-default libyaml-dev libpq-dev postgresql-client-9.6 nodejs \
     && apt-get upgrade -y \
     && apt-get clean \
-    # Consul template
-    && bash /tmp/consul_template_install.sh \
+    # AWSCLI (to be removed in a future release)
+    && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \
+    && unzip -d /tmp /tmp/awscliv2.zip \
+    && /tmp/aws/install \
     # Create our service group and user
     && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
-    # Make wait-for-it executable
-    && chmod a+rx /wait-for-it.sh \
     # cleanup
     && rm -rf /var/lib/apt/lists/* /usr/share/doc /root/.cache/ /tmp/*
 
@@ -35,5 +38,5 @@ WORKDIR $SERVICE_ROOT
 
 # Our entrypoint will pull in our environment variables from Consul and Vault
 # and execute whatever command we provided the container.
-# See https://github.com/articulate/docker-consul-template-bootstrap/blob/master/entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+# See https://github.com/articulate/docker-consul-template-bootstrap
+ENTRYPOINT [ "/entrypoint" ]

--- a/2.5-stretch-slim/Dockerfile
+++ b/2.5-stretch-slim/Dockerfile
@@ -1,10 +1,13 @@
+# syntax=docker/dockerfile:1
 FROM ruby:2.5-slim-stretch
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 
-ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
-ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
+ARG TARGETARCH
+ARG AWSCLI_VERSION=2.9.15
+ADD --chmod=755 https://github.com/articulate/docker-consul-template-bootstrap/releases/latest/download/docker-consul-template-bootstrap_linux_${TARGETARCH} /entrypoint
+ADD --chmod=755 https://raw.githubusercontent.com/vishnubob/wait-for-it/81b1373f17855a4dc21156cfe1694c31d7d1792e/wait-for-it.sh /wait-for-it.sh
 ADD https://deb.nodesource.com/setup_12.x /tmp/setup-node.sh
 
 # - postgresql-client requires the presence of man pages for some reason. Debian-slim doesn't have those by default, so we have to add those as a stub (source: https://github.com/dalibo/temboard/issues/211)
@@ -14,15 +17,15 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     && apt-get update -qq \
     && apt-get install --no-install-recommends -y \
         build-essential imagemagick git wget curl binutils jq sudo unzip \
-        libyaml-dev libpq-dev postgresql-client-9.6 nodejs \
+        ca-certificates libyaml-dev libpq-dev postgresql-client-9.6 nodejs \
     && apt-get upgrade -y \
     && apt-get clean \
-    # Consul template
-    && bash /tmp/consul_template_install.sh \
+    # AWSCLI (to be removed in a future release)
+    && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \
+    && unzip -d /tmp /tmp/awscliv2.zip \
+    && /tmp/aws/install \
     # Create our service group and user
     && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
-    # Make wait-for-it executable
-    && chmod a+rx /wait-for-it.sh \
     # cleanup
     && rm -rf /var/lib/apt/lists/* /usr/share/doc /root/.cache/ /tmp/*
 
@@ -33,5 +36,5 @@ WORKDIR $SERVICE_ROOT
 
 # Our entrypoint will pull in our environment variables from Consul and Vault
 # and execute whatever command we provided the container.
-# See https://github.com/articulate/docker-consul-template-bootstrap/blob/master/entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+# See https://github.com/articulate/docker-consul-template-bootstrap
+ENTRYPOINT [ "/entrypoint" ]

--- a/2.6-bullseye-slim-minimal/Dockerfile
+++ b/2.6-bullseye-slim-minimal/Dockerfile
@@ -1,20 +1,23 @@
+# syntax=docker/dockerfile:1
 FROM ruby:2.6-slim-bullseye
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 
-ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
-ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
+ARG TARGETARCH
+ARG AWSCLI_VERSION=2.9.15
+ADD --chmod=755 https://github.com/articulate/docker-consul-template-bootstrap/releases/latest/download/docker-consul-template-bootstrap_linux_${TARGETARCH} /entrypoint
+ADD --chmod=755 https://raw.githubusercontent.com/vishnubob/wait-for-it/81b1373f17855a4dc21156cfe1694c31d7d1792e/wait-for-it.sh /wait-for-it.sh
 
 RUN apt-get update -qq \
     && apt-get install --no-install-recommends -y \
-        make git wget curl xvfb binutils jq sudo unzip \
+        make git wget curl xvfb binutils jq sudo unzip ca-certificates \
     && apt-get upgrade -y \
     && apt-get clean \
-    # Consul template
-    && bash /tmp/consul_template_install.sh \
-    # Make wait-for-it executable
-    && chmod a+rx /wait-for-it.sh \
+    # AWSCLI (to be removed in a future release)
+    && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \
+    && unzip -d /tmp /tmp/awscliv2.zip \
+    && /tmp/aws/install \
     # Create our service group and user
     && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
     # Cleanup
@@ -24,5 +27,5 @@ WORKDIR $SERVICE_ROOT
 
 # Our entrypoint will pull in our environment variables from Consul and Vault
 # and execute whatever command we provided the container.
-# See https://github.com/articulate/docker-consul-template-bootstrap/blob/master/entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+# See https://github.com/articulate/docker-consul-template-bootstrap
+ENTRYPOINT [ "/entrypoint" ]

--- a/2.6-bullseye-slim-qt/Dockerfile
+++ b/2.6-bullseye-slim-qt/Dockerfile
@@ -1,10 +1,13 @@
+# syntax=docker/dockerfile:1
 FROM ruby:2.6-slim-bullseye
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 
-ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
-ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
+ARG TARGETARCH
+ARG AWSCLI_VERSION=2.9.15
+ADD --chmod=755 https://github.com/articulate/docker-consul-template-bootstrap/releases/latest/download/docker-consul-template-bootstrap_linux_${TARGETARCH} /entrypoint
+ADD --chmod=755 https://raw.githubusercontent.com/vishnubob/wait-for-it/81b1373f17855a4dc21156cfe1694c31d7d1792e/wait-for-it.sh /wait-for-it.sh
 ADD https://deb.nodesource.com/setup_16.x /tmp/setup-node.sh
 
 # - postgresql-client requires the presence of man pages for some reason. Debian-slim doesn't have those by default, so we have to add those as a stub (source: https://github.com/dalibo/temboard/issues/211)
@@ -17,15 +20,15 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     && apt-get install --no-install-recommends -y \
         build-essential imagemagick git wget curl xvfb binutils jq sudo unzip \
         qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools libqt5webkit5-dev \
-        libyaml-dev libpq-dev nodejs postgresql-client \
+        ca-certificates libyaml-dev libpq-dev nodejs postgresql-client \
     && apt-get upgrade -y \
     && apt-get clean \
-    # Consul template
-    && bash /tmp/consul_template_install.sh \
+    # AWSCLI (to be removed in a future release)
+    && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \
+    && unzip -d /tmp /tmp/awscliv2.zip \
+    && /tmp/aws/install \
     # Create our service group and user
     && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
-    # Make wait-for-it executable
-    && chmod a+rx /wait-for-it.sh \
     # cleanup
     && rm -rf /var/lib/apt/lists/* /usr/share/doc /root/.cache/ /tmp/*
 
@@ -36,5 +39,5 @@ WORKDIR $SERVICE_ROOT
 
 # Our entrypoint will pull in our environment variables from Consul and Vault
 # and execute whatever command we provided the container.
-# See https://github.com/articulate/docker-consul-template-bootstrap/blob/master/entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+# See https://github.com/articulate/docker-consul-template-bootstrap
+ENTRYPOINT [ "/entrypoint" ]

--- a/2.6-bullseye-slim/Dockerfile
+++ b/2.6-bullseye-slim/Dockerfile
@@ -1,10 +1,13 @@
+# syntax=docker/dockerfile:1
 FROM ruby:2.6-slim-bullseye
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 
-ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
-ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
+ARG TARGETARCH
+ARG AWSCLI_VERSION=2.9.15
+ADD --chmod=755 https://github.com/articulate/docker-consul-template-bootstrap/releases/latest/download/docker-consul-template-bootstrap_linux_${TARGETARCH} /entrypoint
+ADD --chmod=755 https://raw.githubusercontent.com/vishnubob/wait-for-it/81b1373f17855a4dc21156cfe1694c31d7d1792e/wait-for-it.sh /wait-for-it.sh
 ADD https://deb.nodesource.com/setup_16.x /tmp/setup-node.sh
 
 # - postgresql-client requires the presence of man pages for some reason. Debian-slim doesn't have those by default, so we have to add those as a stub (source: https://github.com/dalibo/temboard/issues/211)
@@ -16,15 +19,15 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     && apt-get update -qq \
     && apt-get install --no-install-recommends -y \
         build-essential imagemagick git wget curl binutils jq sudo unzip \
-        libyaml-dev libpq-dev nodejs postgresql-client \
+        ca-certificates libyaml-dev libpq-dev nodejs postgresql-client \
     && apt-get upgrade -y \
     && apt-get clean \
-    # Consul template
-    && bash /tmp/consul_template_install.sh \
+    # AWSCLI (to be removed in a future release)
+    && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \
+    && unzip -d /tmp /tmp/awscliv2.zip \
+    && /tmp/aws/install \
     # Create our service group and user
     && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
-    # Make wait-for-it executable
-    && chmod a+rx /wait-for-it.sh \
     # cleanup
     && rm -rf /var/lib/apt/lists/* /usr/share/doc /root/.cache/ /tmp/*
 
@@ -35,5 +38,5 @@ WORKDIR $SERVICE_ROOT
 
 # Our entrypoint will pull in our environment variables from Consul and Vault
 # and execute whatever command we provided the container.
-# See https://github.com/articulate/docker-consul-template-bootstrap/blob/master/entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+# See https://github.com/articulate/docker-consul-template-bootstrap
+ENTRYPOINT [ "/entrypoint" ]

--- a/2.6-stretch-slim-minimal/Dockerfile
+++ b/2.6-stretch-slim-minimal/Dockerfile
@@ -1,20 +1,23 @@
+# syntax=docker/dockerfile:1
 FROM ruby:2.6-slim-stretch
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 
-ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
-ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
+ARG TARGETARCH
+ARG AWSCLI_VERSION=2.9.15
+ADD --chmod=755 https://github.com/articulate/docker-consul-template-bootstrap/releases/latest/download/docker-consul-template-bootstrap_linux_${TARGETARCH} /entrypoint
+ADD --chmod=755 https://raw.githubusercontent.com/vishnubob/wait-for-it/81b1373f17855a4dc21156cfe1694c31d7d1792e/wait-for-it.sh /wait-for-it.sh
 
 RUN apt-get update -qq \
     && apt-get install --no-install-recommends -y \
-        make git wget curl xvfb binutils jq sudo unzip \
+        make git wget curl xvfb binutils jq sudo unzip ca-certificates \
     && apt-get upgrade -y \
     && apt-get clean \
-    # Consul template
-    && bash /tmp/consul_template_install.sh \
-    # Make wait-for-it executable
-    && chmod a+rx /wait-for-it.sh \
+    # AWSCLI (to be removed in a future release)
+    && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \
+    && unzip -d /tmp /tmp/awscliv2.zip \
+    && /tmp/aws/install \
     # Create our service group and user
     && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
     # Cleanup
@@ -25,4 +28,4 @@ WORKDIR $SERVICE_ROOT
 # Our entrypoint will pull in our environment variables from Consul and Vault
 # and execute whatever command we provided the container.
 # See https://github.com/articulate/docker-consul-template-bootstrap/blob/master/entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT [ "/entrypoint" ]

--- a/2.6-stretch-slim-qt/Dockerfile
+++ b/2.6-stretch-slim-qt/Dockerfile
@@ -1,10 +1,13 @@
+# syntax=docker/dockerfile:1
 FROM ruby:2.6-slim-stretch
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 
-ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
-ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
+ARG TARGETARCH
+ARG AWSCLI_VERSION=2.9.15
+ADD --chmod=755 https://github.com/articulate/docker-consul-template-bootstrap/releases/latest/download/docker-consul-template-bootstrap_linux_${TARGETARCH} /entrypoint
+ADD --chmod=755 https://raw.githubusercontent.com/vishnubob/wait-for-it/81b1373f17855a4dc21156cfe1694c31d7d1792e/wait-for-it.sh /wait-for-it.sh
 ADD https://deb.nodesource.com/setup_12.x /tmp/setup-node.sh
 
 # - postgresql-client requires the presence of man pages for some reason. Debian-slim doesn't have those by default, so we have to add those as a stub (source: https://github.com/dalibo/temboard/issues/211)
@@ -17,15 +20,15 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     && apt-get install --no-install-recommends -y \
         build-essential imagemagick git wget curl xvfb binutils jq sudo unzip \
         qt5-default libqt5webkit5-dev libyaml-dev libpq-dev postgresql-client-9.6 \
-        nodejs \
+        ca-certificates nodejs \
     && apt-get upgrade -y \
     && apt-get clean \
-    # Consul template
-    && bash /tmp/consul_template_install.sh \
+    # AWSCLI (to be removed in a future release)
+    && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \
+    && unzip -d /tmp /tmp/awscliv2.zip \
+    && /tmp/aws/install \
     # Create our service group and user
     && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
-    # Make wait-for-it executable
-    && chmod a+rx /wait-for-it.sh \
     # cleanup
     && rm -rf /var/lib/apt/lists/* /usr/share/doc /root/.cache/ /tmp/*
 
@@ -36,5 +39,5 @@ WORKDIR $SERVICE_ROOT
 
 # Our entrypoint will pull in our environment variables from Consul and Vault
 # and execute whatever command we provided the container.
-# See https://github.com/articulate/docker-consul-template-bootstrap/blob/master/entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+# See https://github.com/articulate/docker-consul-template-bootstrap
+ENTRYPOINT [ "/entrypoint" ]

--- a/2.6-stretch-slim/Dockerfile
+++ b/2.6-stretch-slim/Dockerfile
@@ -1,10 +1,13 @@
+# syntax=docker/dockerfile:1
 FROM ruby:2.6-slim-stretch
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 
-ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
-ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
+ARG TARGETARCH
+ARG AWSCLI_VERSION=2.9.15
+ADD --chmod=755 https://github.com/articulate/docker-consul-template-bootstrap/releases/latest/download/docker-consul-template-bootstrap_linux_${TARGETARCH} /entrypoint
+ADD --chmod=755 https://raw.githubusercontent.com/vishnubob/wait-for-it/81b1373f17855a4dc21156cfe1694c31d7d1792e/wait-for-it.sh /wait-for-it.sh
 ADD https://deb.nodesource.com/setup_12.x /tmp/setup-node.sh
 
 # - postgresql-client requires the presence of man pages for some reason. Debian-slim doesn't have those by default, so we have to add those as a stub (source: https://github.com/dalibo/temboard/issues/211)
@@ -16,15 +19,15 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     && apt-get update -qq \
     && apt-get install --no-install-recommends -y \
         build-essential imagemagick git wget curl binutils jq sudo unzip \
-        libyaml-dev libpq-dev postgresql-client-9.6 nodejs \
+        ca-certificates libyaml-dev libpq-dev postgresql-client-9.6 nodejs \
     && apt-get upgrade -y \
     && apt-get clean \
-    # Consul template
-    && bash /tmp/consul_template_install.sh \
+    # AWSCLI (to be removed in a future release)
+    && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \
+    && unzip -d /tmp /tmp/awscliv2.zip \
+    && /tmp/aws/install \
     # Create our service group and user
     && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
-    # Make wait-for-it executable
-    && chmod a+rx /wait-for-it.sh \
     # cleanup
     && rm -rf /var/lib/apt/lists/* /usr/share/doc /root/.cache/ /tmp/*
 
@@ -35,5 +38,5 @@ WORKDIR $SERVICE_ROOT
 
 # Our entrypoint will pull in our environment variables from Consul and Vault
 # and execute whatever command we provided the container.
-# See https://github.com/articulate/docker-consul-template-bootstrap/blob/master/entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+# See https://github.com/articulate/docker-consul-template-bootstrap
+ENTRYPOINT [ "/entrypoint" ]

--- a/2.7-bullseye-slim-qt/Dockerfile
+++ b/2.7-bullseye-slim-qt/Dockerfile
@@ -1,10 +1,13 @@
+# syntax=docker/dockerfile:1
 FROM ruby:2.7-slim-bullseye
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 
-ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
-ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
+ARG TARGETARCH
+ARG AWSCLI_VERSION=2.9.15
+ADD --chmod=755 https://github.com/articulate/docker-consul-template-bootstrap/releases/latest/download/docker-consul-template-bootstrap_linux_${TARGETARCH} /entrypoint
+ADD --chmod=755 https://raw.githubusercontent.com/vishnubob/wait-for-it/81b1373f17855a4dc21156cfe1694c31d7d1792e/wait-for-it.sh /wait-for-it.sh
 ADD https://deb.nodesource.com/setup_16.x /tmp/setup-node.sh
 
 # - postgresql-client requires the presence of man pages for some reason. Debian-slim doesn't have those by default, so we have to add those as a stub (source: https://github.com/dalibo/temboard/issues/211)
@@ -17,15 +20,15 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && apt-get install --no-install-recommends -y \
   build-essential imagemagick git wget curl xvfb binutils jq sudo unzip \
   qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools libqt5webkit5-dev \
-  libyaml-dev libpq-dev nodejs postgresql-client \
+  ca-certificates libyaml-dev libpq-dev nodejs postgresql-client \
   && apt-get upgrade -y \
   && apt-get clean \
-  # Consul template
-  && bash /tmp/consul_template_install.sh \
+  # AWSCLI (to be removed in a future release)
+    && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \
+    && unzip -d /tmp /tmp/awscliv2.zip \
+    && /tmp/aws/install \
   # Create our service group and user
   && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
-  # Make wait-for-it executable
-  && chmod a+rx /wait-for-it.sh \
   # cleanup
   && rm -rf /var/lib/apt/lists/* /usr/share/doc /root/.cache/ /tmp/*
 
@@ -36,5 +39,5 @@ WORKDIR $SERVICE_ROOT
 
 # Our entrypoint will pull in our environment variables from Consul and Vault
 # and execute whatever command we provided the container.
-# See https://github.com/articulate/docker-consul-template-bootstrap/blob/master/entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+# See https://github.com/articulate/docker-consul-template-bootstrap
+ENTRYPOINT [ "/entrypoint" ]

--- a/2.7-bullseye-slim/Dockerfile
+++ b/2.7-bullseye-slim/Dockerfile
@@ -1,10 +1,13 @@
+# syntax=docker/dockerfile:1
 FROM ruby:2.7-slim-bullseye
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 
-ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
-ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
+ARG TARGETARCH
+ARG AWSCLI_VERSION=2.9.15
+ADD --chmod=755 https://github.com/articulate/docker-consul-template-bootstrap/releases/latest/download/docker-consul-template-bootstrap_linux_${TARGETARCH} /entrypoint
+ADD --chmod=755 https://raw.githubusercontent.com/vishnubob/wait-for-it/81b1373f17855a4dc21156cfe1694c31d7d1792e/wait-for-it.sh /wait-for-it.sh
 ADD https://deb.nodesource.com/setup_16.x /tmp/setup-node.sh
 
 # - we install Imagemagick in our base image so we can keep it updated in one place, and so we can add a strict security policy by default (see further down)
@@ -14,15 +17,15 @@ RUN bash /tmp/setup-node.sh \
     && apt-get update -qq \
     && apt-get install --no-install-recommends -y \
         build-essential imagemagick git wget curl binutils jq sudo unzip \
-        libyaml-dev libpq-dev nodejs postgresql-client \
+        ca-certificates libyaml-dev libpq-dev nodejs postgresql-client \
     && apt-get upgrade -y \
     && apt-get clean \
-    # Consul template
-    && bash /tmp/consul_template_install.sh \
+    # AWSCLI (to be removed in a future release)
+    && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \
+    && unzip -d /tmp /tmp/awscliv2.zip \
+    && /tmp/aws/install \
     # Create our service group and user
     && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
-    # Make wait-for-it executable
-    && chmod a+rx /wait-for-it.sh \
     # cleanup
     && rm -rf /var/lib/apt/lists/* /usr/share/doc /root/.cache/ /tmp/*
 
@@ -33,5 +36,5 @@ WORKDIR $SERVICE_ROOT
 
 # Our entrypoint will pull in our environment variables from Consul and Vault
 # and execute whatever command we provided the container.
-# See https://github.com/articulate/docker-consul-template-bootstrap/blob/master/entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+# See https://github.com/articulate/docker-consul-template-bootstrap
+ENTRYPOINT [ "/entrypoint" ]

--- a/2.7-buster-slim-minimal/Dockerfile
+++ b/2.7-buster-slim-minimal/Dockerfile
@@ -1,20 +1,23 @@
+# syntax=docker/dockerfile:1
 FROM ruby:2.7-slim-buster
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 
-ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
-ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
+ARG TARGETARCH
+ARG AWSCLI_VERSION=2.9.15
+ADD --chmod=755 https://github.com/articulate/docker-consul-template-bootstrap/releases/latest/download/docker-consul-template-bootstrap_linux_${TARGETARCH} /entrypoint
+ADD --chmod=755 https://raw.githubusercontent.com/vishnubob/wait-for-it/81b1373f17855a4dc21156cfe1694c31d7d1792e/wait-for-it.sh /wait-for-it.sh
 
 RUN apt-get update -qq \
     && apt-get install --no-install-recommends -y \
-        make git wget curl xvfb binutils jq sudo unzip \
+        make git wget curl xvfb binutils jq sudo unzip ca-certificates \
     && apt-get upgrade -y \
     && apt-get clean \
-    # Consul template
-    && bash /tmp/consul_template_install.sh \
-    # Make wait-for-it executable
-    && chmod a+rx /wait-for-it.sh \
+    # AWSCLI (to be removed in a future release)
+    && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \
+    && unzip -d /tmp /tmp/awscliv2.zip \
+    && /tmp/aws/install \
     # Create our service group and user
     && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
     # Cleanup
@@ -25,4 +28,4 @@ WORKDIR $SERVICE_ROOT
 # Our entrypoint will pull in our environment variables from Consul and Vault
 # and execute whatever command we provided the container.
 # See https://github.com/articulate/docker-consul-template-bootstrap/blob/master/entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT [ "/entrypoint" ]

--- a/2.7-buster-slim-qt/Dockerfile
+++ b/2.7-buster-slim-qt/Dockerfile
@@ -1,10 +1,13 @@
+# syntax=docker/dockerfile:1
 FROM ruby:2.7-slim-buster
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 
-ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
-ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
+ARG TARGETARCH
+ARG AWSCLI_VERSION=2.9.15
+ADD --chmod=755 https://github.com/articulate/docker-consul-template-bootstrap/releases/latest/download/docker-consul-template-bootstrap_linux_${TARGETARCH} /entrypoint
+ADD --chmod=755 https://raw.githubusercontent.com/vishnubob/wait-for-it/81b1373f17855a4dc21156cfe1694c31d7d1792e/wait-for-it.sh /wait-for-it.sh
 ADD https://deb.nodesource.com/setup_12.x /tmp/setup-node.sh
 
 # - postgresql-client requires the presence of man pages for some reason. Debian-slim doesn't have those by default, so we have to add those as a stub (source: https://github.com/dalibo/temboard/issues/211)
@@ -17,15 +20,15 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     && apt-get install --no-install-recommends -y \
         build-essential imagemagick git wget curl binutils jq sudo unzip \
         qt5-default libqt5webkit5-dev libyaml-dev libpq-dev postgresql-client \
-        nodejs \
+        ca-certificates nodejs \
     && apt-get upgrade -y \
     && apt-get clean \
-    # Consul template
-    && bash /tmp/consul_template_install.sh \
+    # AWSCLI (to be removed in a future release)
+    && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \
+    && unzip -d /tmp /tmp/awscliv2.zip \
+    && /tmp/aws/install \
     # Create our service group and user
     && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
-    # Make wait-for-it executable
-    && chmod a+rx /wait-for-it.sh \
     # cleanup
     && rm -rf /var/lib/apt/lists/* /usr/share/doc /root/.cache/ /tmp/*
 
@@ -36,5 +39,5 @@ WORKDIR $SERVICE_ROOT
 
 # Our entrypoint will pull in our environment variables from Consul and Vault
 # and execute whatever command we provided the container.
-# See https://github.com/articulate/docker-consul-template-bootstrap/blob/master/entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+# See https://github.com/articulate/docker-consul-template-bootstrap
+ENTRYPOINT [ "/entrypoint" ]

--- a/2.7-buster-slim/Dockerfile
+++ b/2.7-buster-slim/Dockerfile
@@ -1,10 +1,13 @@
+# syntax=docker/dockerfile:1
 FROM ruby:2.7-slim-buster
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 
-ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
-ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
+ARG TARGETARCH
+ARG AWSCLI_VERSION=2.9.15
+ADD --chmod=755 https://github.com/articulate/docker-consul-template-bootstrap/releases/latest/download/docker-consul-template-bootstrap_linux_${TARGETARCH} /entrypoint
+ADD --chmod=755 https://raw.githubusercontent.com/vishnubob/wait-for-it/81b1373f17855a4dc21156cfe1694c31d7d1792e/wait-for-it.sh /wait-for-it.sh
 ADD https://deb.nodesource.com/setup_12.x /tmp/setup-node.sh
 
 # - postgresql-client requires the presence of man pages for some reason. Debian-slim doesn't have those by default, so we have to add those as a stub (source: https://github.com/dalibo/temboard/issues/211)
@@ -16,15 +19,15 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     && apt-get update -qq \
     && apt-get install --no-install-recommends -y \
         build-essential imagemagick git wget curl binutils jq sudo unzip \
-        libyaml-dev libpq-dev postgresql-client nodejs \
+        ca-certificates libyaml-dev libpq-dev postgresql-client nodejs \
     && apt-get upgrade -y \
     && apt-get clean \
-    # Consul template
-    && bash /tmp/consul_template_install.sh \
+    # AWSCLI (to be removed in a future release)
+    && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \
+    && unzip -d /tmp /tmp/awscliv2.zip \
+    && /tmp/aws/install \
     # Create our service group and user
     && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
-    # Make wait-for-it executable
-    && chmod a+rx /wait-for-it.sh \
     # cleanup
     && rm -rf /var/lib/apt/lists/* /usr/share/doc /root/.cache/ /tmp/*
 
@@ -35,5 +38,5 @@ WORKDIR $SERVICE_ROOT
 
 # Our entrypoint will pull in our environment variables from Consul and Vault
 # and execute whatever command we provided the container.
-# See https://github.com/articulate/docker-consul-template-bootstrap/blob/master/entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+# See https://github.com/articulate/docker-consul-template-bootstrap
+ENTRYPOINT [ "/entrypoint" ]

--- a/3.1-bullseye-slim-minimal/Dockerfile
+++ b/3.1-bullseye-slim-minimal/Dockerfile
@@ -1,20 +1,23 @@
+# syntax=docker/dockerfile:1
 FROM ruby:3.1-slim-bullseye
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 
-ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
-ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
+ARG TARGETARCH
+ARG AWSCLI_VERSION=2.9.15
+ADD --chmod=755 https://github.com/articulate/docker-consul-template-bootstrap/releases/latest/download/docker-consul-template-bootstrap_linux_${TARGETARCH} /entrypoint
+ADD --chmod=755 https://raw.githubusercontent.com/vishnubob/wait-for-it/81b1373f17855a4dc21156cfe1694c31d7d1792e/wait-for-it.sh /wait-for-it.sh
 
 RUN apt-get update -qq \
     && apt-get install --no-install-recommends -y \
-        make git wget curl binutils jq sudo unzip \
+        make git wget curl binutils jq sudo unzip ca-certificates \
     && apt-get upgrade -y \
     && apt-get clean \
-    # Consul template
-    && bash /tmp/consul_template_install.sh \
-    # Make wait-for-it executable
-    && chmod a+rx /wait-for-it.sh \
+    # AWSCLI (to be removed in a future release)
+    && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \
+    && unzip -d /tmp /tmp/awscliv2.zip \
+    && /tmp/aws/install \
     # Create our service group and user
     && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
     # Cleanup
@@ -24,5 +27,5 @@ WORKDIR $SERVICE_ROOT
 
 # Our entrypoint will pull in our environment variables from Consul and Vault
 # and execute whatever command we provided the container.
-# See https://github.com/articulate/docker-consul-template-bootstrap/blob/master/entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+# See https://github.com/articulate/docker-consul-template-bootstrap
+ENTRYPOINT [ "/entrypoint" ]

--- a/3.1-bullseye-slim-qt/Dockerfile
+++ b/3.1-bullseye-slim-qt/Dockerfile
@@ -1,10 +1,13 @@
+# syntax=docker/dockerfile:1
 FROM ruby:3.1-slim-bullseye
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 
-ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
-ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
+ARG TARGETARCH
+ARG AWSCLI_VERSION=2.9.15
+ADD --chmod=755 https://github.com/articulate/docker-consul-template-bootstrap/releases/latest/download/docker-consul-template-bootstrap_linux_${TARGETARCH} /entrypoint
+ADD --chmod=755 https://raw.githubusercontent.com/vishnubob/wait-for-it/81b1373f17855a4dc21156cfe1694c31d7d1792e/wait-for-it.sh /wait-for-it.sh
 ADD https://deb.nodesource.com/setup_16.x /tmp/setup-node.sh
 
 # - postgresql-client requires the presence of man pages for some reason. Debian-slim doesn't have those by default, so we have to add those as a stub (source: https://github.com/dalibo/temboard/issues/211)
@@ -17,15 +20,15 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     && apt-get install --no-install-recommends -y \
         build-essential imagemagick git wget curl xvfb binutils jq sudo unzip \
         qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools libqt5webkit5-dev \
-        libyaml-dev libpq-dev nodejs postgresql-client \
+        ca-certificates libyaml-dev libpq-dev nodejs postgresql-client \
     && apt-get upgrade -y \
     && apt-get clean \
-    # Consul template
-    && bash /tmp/consul_template_install.sh \
+    # AWSCLI (to be removed in a future release)
+    && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \
+    && unzip -d /tmp /tmp/awscliv2.zip \
+    && /tmp/aws/install \
     # Create our service group and user
     && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
-    # Make wait-for-it executable
-    && chmod a+rx /wait-for-it.sh \
     # cleanup
     && rm -rf /var/lib/apt/lists/* /usr/share/doc /root/.cache/ /tmp/*
 
@@ -36,5 +39,5 @@ WORKDIR $SERVICE_ROOT
 
 # Our entrypoint will pull in our environment variables from Consul and Vault
 # and execute whatever command we provided the container.
-# See https://github.com/articulate/docker-consul-template-bootstrap/blob/master/entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+# See https://github.com/articulate/docker-consul-template-bootstrap
+ENTRYPOINT [ "/entrypoint" ]

--- a/3.1-bullseye-slim/Dockerfile
+++ b/3.1-bullseye-slim/Dockerfile
@@ -1,10 +1,13 @@
+# syntax=docker/dockerfile:1
 FROM ruby:3.1-slim-bullseye
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 
-ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
-ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
+ARG TARGETARCH
+ARG AWSCLI_VERSION=2.9.15
+ADD --chmod=755 https://github.com/articulate/docker-consul-template-bootstrap/releases/latest/download/docker-consul-template-bootstrap_linux_${TARGETARCH} /entrypoint
+ADD --chmod=755 https://raw.githubusercontent.com/vishnubob/wait-for-it/81b1373f17855a4dc21156cfe1694c31d7d1792e/wait-for-it.sh /wait-for-it.sh
 ADD https://deb.nodesource.com/setup_16.x /tmp/setup-node.sh
 
 # - postgresql-client requires the presence of man pages for some reason. Debian-slim doesn't have those by default, so we have to add those as a stub (source: https://github.com/dalibo/temboard/issues/211)
@@ -16,15 +19,15 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     && apt-get update -qq \
     && apt-get install --no-install-recommends -y \
         build-essential imagemagick git wget curl binutils jq sudo unzip \
-        libyaml-dev libpq-dev nodejs postgresql-client \
+        ca-certificates libyaml-dev libpq-dev nodejs postgresql-client \
     && apt-get upgrade -y \
     && apt-get clean \
-    # Consul template
-    && bash /tmp/consul_template_install.sh \
+    # AWSCLI (to be removed in a future release)
+    && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \
+    && unzip -d /tmp /tmp/awscliv2.zip \
+    && /tmp/aws/install \
     # Create our service group and user
     && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
-    # Make wait-for-it executable
-    && chmod a+rx /wait-for-it.sh \
     # cleanup
     && rm -rf /var/lib/apt/lists/* /usr/share/doc /root/.cache/ /tmp/*
 
@@ -35,5 +38,5 @@ WORKDIR $SERVICE_ROOT
 
 # Our entrypoint will pull in our environment variables from Consul and Vault
 # and execute whatever command we provided the container.
-# See https://github.com/articulate/docker-consul-template-bootstrap/blob/master/entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+# See https://github.com/articulate/docker-consul-template-bootstrap
+ENTRYPOINT [ "/entrypoint" ]


### PR DESCRIPTION
Upgrades to latest docker-consul-template-bootstrap

Improves build workflow by bypassing cache once a week (and manually) and building, but not pushing on PRs

BREAKING CHANGE: removes consul-template and vault executables