### PR TITLE
build(docker): symlink /entrypoint.sh to new /entrypoint

### DIFF
--- a/2.5-stretch-slim-minimal/Dockerfile
+++ b/2.5-stretch-slim-minimal/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update -qq \
         make git wget curl xvfb binutils jq sudo unzip ca-certificates \
     && apt-get upgrade -y \
     && apt-get clean \
+    && ln -s /entrypoint /entrypoint.sh \
     # AWSCLI (to be removed in a future release)
     && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \
     && unzip -d /tmp /tmp/awscliv2.zip \

--- a/2.5-stretch-slim-qt/Dockerfile
+++ b/2.5-stretch-slim-qt/Dockerfile
@@ -22,6 +22,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
         qt5-default libyaml-dev libpq-dev postgresql-client-9.6 nodejs \
     && apt-get upgrade -y \
     && apt-get clean \
+    && ln -s /entrypoint /entrypoint.sh \
     # AWSCLI (to be removed in a future release)
     && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \
     && unzip -d /tmp /tmp/awscliv2.zip \

--- a/2.5-stretch-slim/Dockerfile
+++ b/2.5-stretch-slim/Dockerfile
@@ -20,6 +20,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
         ca-certificates libyaml-dev libpq-dev postgresql-client-9.6 nodejs \
     && apt-get upgrade -y \
     && apt-get clean \
+    && ln -s /entrypoint /entrypoint.sh \
     # AWSCLI (to be removed in a future release)
     && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \
     && unzip -d /tmp /tmp/awscliv2.zip \

--- a/2.6-bullseye-slim-minimal/Dockerfile
+++ b/2.6-bullseye-slim-minimal/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update -qq \
         make git wget curl xvfb binutils jq sudo unzip ca-certificates \
     && apt-get upgrade -y \
     && apt-get clean \
+    && ln -s /entrypoint /entrypoint.sh \
     # AWSCLI (to be removed in a future release)
     && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \
     && unzip -d /tmp /tmp/awscliv2.zip \

--- a/2.6-bullseye-slim-qt/Dockerfile
+++ b/2.6-bullseye-slim-qt/Dockerfile
@@ -23,6 +23,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
         ca-certificates libyaml-dev libpq-dev nodejs postgresql-client \
     && apt-get upgrade -y \
     && apt-get clean \
+    && ln -s /entrypoint /entrypoint.sh \
     # AWSCLI (to be removed in a future release)
     && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \
     && unzip -d /tmp /tmp/awscliv2.zip \

--- a/2.6-bullseye-slim/Dockerfile
+++ b/2.6-bullseye-slim/Dockerfile
@@ -22,6 +22,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
         ca-certificates libyaml-dev libpq-dev nodejs postgresql-client \
     && apt-get upgrade -y \
     && apt-get clean \
+    && ln -s /entrypoint /entrypoint.sh \
     # AWSCLI (to be removed in a future release)
     && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \
     && unzip -d /tmp /tmp/awscliv2.zip \

--- a/2.6-stretch-slim-minimal/Dockerfile
+++ b/2.6-stretch-slim-minimal/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update -qq \
         make git wget curl xvfb binutils jq sudo unzip ca-certificates \
     && apt-get upgrade -y \
     && apt-get clean \
+    && ln -s /entrypoint /entrypoint.sh \
     # AWSCLI (to be removed in a future release)
     && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \
     && unzip -d /tmp /tmp/awscliv2.zip \

--- a/2.6-stretch-slim-qt/Dockerfile
+++ b/2.6-stretch-slim-qt/Dockerfile
@@ -23,6 +23,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
         ca-certificates nodejs \
     && apt-get upgrade -y \
     && apt-get clean \
+    && ln -s /entrypoint /entrypoint.sh \
     # AWSCLI (to be removed in a future release)
     && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \
     && unzip -d /tmp /tmp/awscliv2.zip \

--- a/2.6-stretch-slim/Dockerfile
+++ b/2.6-stretch-slim/Dockerfile
@@ -22,6 +22,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
         ca-certificates libyaml-dev libpq-dev postgresql-client-9.6 nodejs \
     && apt-get upgrade -y \
     && apt-get clean \
+    && ln -s /entrypoint /entrypoint.sh \
     # AWSCLI (to be removed in a future release)
     && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \
     && unzip -d /tmp /tmp/awscliv2.zip \

--- a/2.7-bullseye-slim-qt/Dockerfile
+++ b/2.7-bullseye-slim-qt/Dockerfile
@@ -15,22 +15,23 @@ ADD https://deb.nodesource.com/setup_16.x /tmp/setup-node.sh
 # - We want npm in our base image. To get it, we must install nodejs. There is one in apt-get, but it's super old (version ~4). To get a newer node we must first add the nodesource PPA.
 #   Source: https://github.com/nodesource/distributions/blob/master/README.md#deb
 RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
-  && bash /tmp/setup-node.sh \
-  && apt-get update -qq \
-  && apt-get install --no-install-recommends -y \
-  build-essential imagemagick git wget curl xvfb binutils jq sudo unzip \
-  qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools libqt5webkit5-dev \
-  ca-certificates libyaml-dev libpq-dev nodejs postgresql-client \
-  && apt-get upgrade -y \
-  && apt-get clean \
-  # AWSCLI (to be removed in a future release)
+    && bash /tmp/setup-node.sh \
+    && apt-get update -qq \
+    && apt-get install --no-install-recommends -y \
+        build-essential imagemagick git wget curl xvfb binutils jq sudo unzip \
+        qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools libqt5webkit5-dev \
+        ca-certificates libyaml-dev libpq-dev nodejs postgresql-client \
+    && apt-get upgrade -y \
+    && apt-get clean \
+    && ln -s /entrypoint /entrypoint.sh \
+    # AWSCLI (to be removed in a future release)
     && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \
     && unzip -d /tmp /tmp/awscliv2.zip \
     && /tmp/aws/install \
-  # Create our service group and user
-  && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
-  # cleanup
-  && rm -rf /var/lib/apt/lists/* /usr/share/doc /root/.cache/ /tmp/*
+    # Create our service group and user
+    && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
+    # cleanup
+    && rm -rf /var/lib/apt/lists/* /usr/share/doc /root/.cache/ /tmp/*
 
 # Add a strict security policy for Imagemagick
 COPY imagemagick-policy.xml /etc/ImageMagick-8/policy.xml

--- a/2.7-bullseye-slim/Dockerfile
+++ b/2.7-bullseye-slim/Dockerfile
@@ -20,6 +20,7 @@ RUN bash /tmp/setup-node.sh \
         ca-certificates libyaml-dev libpq-dev nodejs postgresql-client \
     && apt-get upgrade -y \
     && apt-get clean \
+    && ln -s /entrypoint /entrypoint.sh \
     # AWSCLI (to be removed in a future release)
     && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \
     && unzip -d /tmp /tmp/awscliv2.zip \

--- a/2.7-buster-slim-minimal/Dockerfile
+++ b/2.7-buster-slim-minimal/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update -qq \
         make git wget curl xvfb binutils jq sudo unzip ca-certificates \
     && apt-get upgrade -y \
     && apt-get clean \
+    && ln -s /entrypoint /entrypoint.sh \
     # AWSCLI (to be removed in a future release)
     && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \
     && unzip -d /tmp /tmp/awscliv2.zip \

--- a/2.7-buster-slim-qt/Dockerfile
+++ b/2.7-buster-slim-qt/Dockerfile
@@ -23,6 +23,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
         ca-certificates nodejs \
     && apt-get upgrade -y \
     && apt-get clean \
+    && ln -s /entrypoint /entrypoint.sh \
     # AWSCLI (to be removed in a future release)
     && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \
     && unzip -d /tmp /tmp/awscliv2.zip \

--- a/2.7-buster-slim/Dockerfile
+++ b/2.7-buster-slim/Dockerfile
@@ -22,6 +22,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
         ca-certificates libyaml-dev libpq-dev postgresql-client nodejs \
     && apt-get upgrade -y \
     && apt-get clean \
+    && ln -s /entrypoint /entrypoint.sh \
     # AWSCLI (to be removed in a future release)
     && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \
     && unzip -d /tmp /tmp/awscliv2.zip \

--- a/3.1-bullseye-slim-minimal/Dockerfile
+++ b/3.1-bullseye-slim-minimal/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update -qq \
         make git wget curl binutils jq sudo unzip ca-certificates \
     && apt-get upgrade -y \
     && apt-get clean \
+    && ln -s /entrypoint /entrypoint.sh \
     # AWSCLI (to be removed in a future release)
     && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \
     && unzip -d /tmp /tmp/awscliv2.zip \

--- a/3.1-bullseye-slim-qt/Dockerfile
+++ b/3.1-bullseye-slim-qt/Dockerfile
@@ -23,6 +23,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
         ca-certificates libyaml-dev libpq-dev nodejs postgresql-client \
     && apt-get upgrade -y \
     && apt-get clean \
+    && ln -s /entrypoint /entrypoint.sh \
     # AWSCLI (to be removed in a future release)
     && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \
     && unzip -d /tmp /tmp/awscliv2.zip \

--- a/3.1-bullseye-slim/Dockerfile
+++ b/3.1-bullseye-slim/Dockerfile
@@ -22,6 +22,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
         ca-certificates libyaml-dev libpq-dev nodejs postgresql-client \
     && apt-get upgrade -y \
     && apt-get clean \
+    && ln -s /entrypoint /entrypoint.sh \
     # AWSCLI (to be removed in a future release)
     && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \
     && unzip -d /tmp /tmp/awscliv2.zip \


### PR DESCRIPTION
There's a lot of processes that are assuming /entrypoint.sh yet. Symlink this to the new entrypoint to allow for a migration