### PR TITLE
ci: add merge queue, slim runners, and auto-merge for bot PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,4 @@
 * @articulate/devex
+
+# Allow Botzo to approve dependency bumps (and related updates)
+/.github/workflows/ @articulate/devex @botzo

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,9 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    commit-message:
+      prefix: ci
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -1,0 +1,22 @@
+name: Auto-merge Dependencies
+
+on:
+  pull_request:
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-slim
+    if: >
+      github.event.pull_request.user.login == 'dependabot[bot]' ||
+      github.event.pull_request.user.login == 'articulate-automation[bot]'
+    steps:
+      - name: Approve PR
+        env:
+          GH_TOKEN: ${{ secrets.BOTZO_GH_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+        run: gh pr review --approve "$PR" -R "$GITHUB_REPOSITORY"
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.BOTZO_GH_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+        run: gh pr merge --auto --squash "$PR" -R "$GITHUB_REPOSITORY"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,6 +2,7 @@ name: Build
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - main
@@ -17,7 +18,7 @@ on:
 
 jobs:
   setup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
       - name: Find Dockerfiles
@@ -51,17 +52,25 @@ jobs:
       - uses: docker/build-push-action@v7
         with:
           context: ${{ steps.meta.outputs.context }}
-          pull: ${{ github.event_name != 'pull_request' }}
-          push: ${{ github.event_name != 'pull_request' }}
+          pull: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
+          push: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
           tags: ${{ steps.meta.outputs.tags }}
           platforms: linux/amd64,linux/arm64/v8
           cache-from: type=registry,ref=${{ steps.meta.outputs.cache }}
           cache-to: type=inline
           no-cache: ${{ github.event.schedule == '0 0 * * 0' || (github.event_name == 'workflow_dispatch' && inputs.no-cache) }}
+  build-complete:
+    if: always()
+    runs-on: ubuntu-slim
+    needs: [build]
+    steps:
+      - name: Verify build succeeded
+        run: |
+          [ "${{ needs.build.result }}" = "success" ] || exit 1
   dockerhub:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: build
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
     steps:
       - uses: actions/checkout@v6
       - uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # pin@v5.0.0
@@ -71,8 +80,8 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           short-description: ${{ github.event.repository.description }}
   notify:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: build
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
     steps:
       - run: curl ${{ secrets.DMS_URL }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,10 +1,12 @@
 name: Lint
 
-on: pull_request
+on:
+  pull_request:
+  merge_group:
 
 jobs:
   setup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
       - name: Find Dockerfiles
@@ -25,3 +27,11 @@ jobs:
         with:
           dockerfile: ${{ matrix.dockerfile }}
           ignore: DL3008
+  lint-complete:
+    if: always()
+    runs-on: ubuntu-slim
+    needs: [lint]
+    steps:
+      - name: Verify lint succeeded
+        run: |
+          [ "${{ needs.lint.result }}" = "success" ] || exit 1


### PR DESCRIPTION
Ports articulate/docker-debian#25: merge_group triggers, ubuntu-slim for lightweight jobs, build-complete/lint-complete gate jobs, grouped Dependabot updates, and a Botzo auto-merge workflow.